### PR TITLE
feat(api): envio de email no cadastro de usuário

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -2,3 +2,4 @@ DB_HOST=localhost
 DB_USER=root
 DB_PASS=
 DB_NAME=apropriacaohoras
+SERVICE_EMAIL=http://url/do/servico/de/envio/email

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "apropricaohoras",
+  "name": "apropriacaohoras",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -4958,6 +4958,11 @@
         "is-property": "^1.0.2"
       }
     },
+    "generate-password": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/generate-password/-/generate-password-1.5.1.tgz",
+      "integrity": "sha512-XdsyfiF4mKoOEuzA44w9jSNav50zOurdWOV3V8DbA7SJIxR3Xm9ob14HKYTnMQOPX3ylqiJMnQF0wEa8gXZIMw=="
+    },
     "gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
@@ -7340,6 +7345,11 @@
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
       }
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-modules-regexp": {
       "version": "1.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -23,10 +23,12 @@
     "bcrypt": "^4.0.1",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "generate-password": "^1.5.1",
     "mysql2": "^2.0.2",
-    "sequelize": "^5.21.2",
-    "dotenv": "^8.2.0"
+    "node-fetch": "^2.6.0",
+    "sequelize": "^5.21.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/api/src/controllers/acoes.js
+++ b/api/src/controllers/acoes.js
@@ -1,5 +1,6 @@
 import db from '../models'
 import sequelize from 'sequelize'
+import fetch from 'node-fetch'
 
 module.exports = {
   horas: {
@@ -40,5 +41,42 @@ module.exports = {
         include: [{ model: projetos, attributes: ['nome'], as: 'id_projeto' }]
       })
     }
+  },
+
+  usuarios: {
+    criarMensagem: (nome, email, senha) => {
+      return `
+        <h3>Olá ${nome},</h3>
+        <p>A sua senha do sistema de registro de horas é:</p>
+        <p><strong>${senha}</strong></p>
+        <p>Faça o login para acessar o sistema: <a href="https://servicos.spurbanismo.gov.sp.br/apropriacaohoras/login?email=${email}">login</a></p>
+        <p>Se preferir defina uma nova senha pelo link abaixo:</p>
+        <p><a href="https://servicos.spurbanismo.gov.sp.br/apropriacaohoras/reset?email=${email}&reset=${senha}">Redefinir senha</a></p>
+      `
+    }
+  },
+
+  enviarEmail: (email, assunto, mensagem) => {
+    const data = {
+      'Para': email,
+      'Assunto': assunto,
+      'Mensagem': mensagem
+    }
+
+    const convert = json => {
+      let str = []
+      for (const key in json) {
+        if (json.hasOwnProperty(key)) {
+          str.push(encodeURIComponent(key) + "=" + encodeURIComponent(json[key]))
+        }
+      }
+      return str.join("&")
+    }
+
+    return fetch(process.env.SERVICE_EMAIL, {
+      method: 'post',
+      body: convert(data),
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+    })
   }
 }

--- a/api/src/controllers/exceptions.js
+++ b/api/src/controllers/exceptions.js
@@ -1,0 +1,15 @@
+module.exports = {
+  notAuthorized: (res, message) => res.status(403).send({ message }),
+  badRequest: (res, { message, error }) => {
+    return res.status(400).send({
+      message: message || 'Erro na requisição',
+      error: error || 'Erro!'
+    })
+  },
+  internalError: (res, { message, error }) => {
+    return res.status(500).send({
+      message: message || 'Erro interno',
+      error: error || 'Erro!'
+    })
+  }
+}

--- a/api/src/controllers/usuarios.controller.js
+++ b/api/src/controllers/usuarios.controller.js
@@ -1,57 +1,70 @@
 const db = require('../models')
 const Usuario = db.usuarios
-
 const dao = require('./dao')
-const { hashSync } = require('bcrypt')
 
-const exceptionsDefault = error => {
-  return {
-    message: error.message || 'Erro na requisição',
-    error
-  }
-}
+import { generate } from 'generate-password'
+import { hashSync } from 'bcrypt'
+import { notAuthorized, badRequest, internalError } from './exceptions'
+import { enviarEmail, usuarios } from './acoes'
 
-exports.create = async (req, res) => {
-  const { email, password } = req.body
-
-  if (!email || !password) {
-    return res
-      .status(400)
-      .send(
-        exceptionsDefault('Ausência de email ou password na body da requisição')
-      )
+exports.create = (req, res) => {
+  if (!req.admin) {
+    return notAuthorized(res, 'Usuário não autorizado')
   }
 
-  const hash = hashSync(req.body.password, 10)
+  const { email, nprodam, nome } = req.body
 
-  try {
-    let user = await Usuario.create(Object.assign(req.body, { password: hash }))
-    let data = await user.authorize()
+  if (!email || !nprodam || !nome ) {
+    return badRequest(res, { message: 'Ausência de email, password na body da requisição' })
+  }
 
-    return res.json({
-      message: 'Usuário criado',
-      data
+  const password = generate({
+    length: 18,
+    numbers: true,
+    uppercase: false
+  })
+
+  const hash = hashSync(password, 10)
+  const emailBody = usuarios.criarMensagem(nome, email, password)
+
+  enviarEmail(email, 'Registro de horas | São Paulo Urbanismo', emailBody)
+    .then(async () => {
+      try {
+        const user = await Usuario.create(Object.assign(req.body, { password: hash }))
+        await user.authorize()
+      } catch(err) {
+        return badRequest(res, {
+          error: err,
+          message: 'Erro de requisição'
+        })
+      }
+
+      return res.json({
+        message: `Usuário criado. Solicitação de acesso enviado para ${email}`,
+      })
     })
-  } catch (err) {
-    return res.status(400).send(exceptionsDefault(err))
-  }
+    .catch(err => {
+      return internalError(res, {
+        error: err,
+        message: 'Erro no envio'
+      })
+    })
 }
 
 exports.login = async (req, res) => {
   const { email, password } = req.body
   if (!email || !password) {
-    return res
-      .status(400)
-      .send(
-        exceptionsDefault('Ausência de email ou password na body da requisição')
-      )
+    return notAuthorized(res, 'Ausência de email ou password na body da requisição')
   }
 
   try {
     let user = await Usuario.authenticate(email, password)
     return res.json(user)
   } catch (err) {
-    return res.status(400).send(exceptionsDefault(err))
+    return badRequest(res, {
+      error: err,
+      message: 'Erro de autenticação'
+    })
   }
 }
 
@@ -60,15 +73,16 @@ exports.logout = async (req, res) => {
 
   try {
     if (!req.authorized) {
-      return res
-        .status(403)
-        .send(exceptionsDefault('Erro no token de autenticação'))
+      return notAuthorized(res, 'Erro no token de autenticação')
     }
 
     let user = await Usuario.logout(token)
     return res.status(204).send({ user })
   } catch (err) {
-    return res.status(400).send(exceptionsDefault(err))
+    return badRequest(res, {
+      error: err,
+      message: 'Erro ao realizar logout'
+    })
   }
 }
 
@@ -88,9 +102,10 @@ exports.findAll = (req, res) => {
       })
     })
     .catch(err => {
-      res
-        .status(500)
-        .send(exceptionsDefault('Ocorreu um erro ao encontrar usuários'))
+      return internalError(res, {
+        error: err,
+        message: 'Ocorreu um erro ao encontrar usuários'
+      })
     })
 }
 exports.findOne = (req, res) => {
@@ -106,15 +121,16 @@ exports.findOne = (req, res) => {
       })
     })
     .catch(err => {
-      res
-        .status(400)
-        .send(exceptionsDefault('Ocorreu um erro ao encontrar usuário'))
+      return badRequest(res, {
+        error: err,
+        message: 'Ocorreu um erro ao encontrar usuário'
+      })
     })
 }
 
 exports.update = (req, res) => {
   if (!req.authorized) {
-    res.status(403).send(exceptionsDefault('Operação não autorizada'))
+    return notAuthorized(res, 'Atualização não autorizada. Usuário não autorizado')
   } else if (req.body.password) {
     req.body.password = hashSync(req.body.password, 10)
     dao.update(req, res, Usuario)
@@ -124,11 +140,11 @@ exports.update = (req, res) => {
 }
 exports.delete = (req, res) => {
   if (!req.authorized)
-    res.status(403).send(exceptionsDefault('Operação não autorizada'))
+  return notAuthorized(res, 'Atualização não autorizada. Usuário não autorizado')
   dao.delete(req, res, Usuario)
 }
 exports.deleteAll = (req, res) => {
   if (!req.authorized)
-    res.status(403).send(exceptionsDefault('Operação não autorizada'))
+  return notAuthorized(res, 'Atualização não autorizada. Usuário não autorizado')
   dao.deleteAll(req, res, Usuario)
 }


### PR DESCRIPTION
Resolve backend de #38.

envia email no momento do cadastro de usuário
POST /usuarios (apenas admins)
```json
{
  "email":"email@spurbanismo.sp.gov.br",
  "nprodam":"e5555",
  "nome": "Novo Usuário",
  "admin": true
}
```
![Screenshot_2020-06-29 Registro de horas São Paulo Urbanismo - yubathom gmail com - Gmail](https://user-images.githubusercontent.com/4117768/86074439-5b50c900-ba5c-11ea-9e3e-4364a982cbc0.png)

